### PR TITLE
The utf8_encode() function is deprecated in php 8 and has been replac…

### DIFF
--- a/src/GameQ/GameQ.php
+++ b/src/GameQ/GameQ.php
@@ -124,10 +124,10 @@ class GameQ
      */
     public function __construct()
     {
-        // Check for missing utf8_encode function
-        if (!function_exists('utf8_encode')) {
-            throw new \Exception("PHP's utf8_encode() function is required - "
-                . "http://php.net/manual/en/function.utf8-encode.php.  Check your php installation.");
+        // Check for missing mb_convert_encoding function
+        if (!function_exists('mb_convert_encoding')) {
+            throw new \Exception("PHP's mb_convert_encoding() function is required - "
+                . "https://www.php.net/manual/en/function.mb-convert-encoding.php.  Check your php installation.");
         }
     }
 

--- a/src/GameQ/Protocols/Codmw2.php
+++ b/src/GameQ/Protocols/Codmw2.php
@@ -63,7 +63,7 @@ class Codmw2 extends Quake3
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $player['name'] = utf8_encode(trim(($playerInfo->readString('"'))));
+            $player['name'] = mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8");
 
             // Add player
             $players[] = $player;

--- a/src/GameQ/Protocols/Codmw2.php
+++ b/src/GameQ/Protocols/Codmw2.php
@@ -63,7 +63,7 @@ class Codmw2 extends Quake3
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $player['name'] = mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8");
+            $player['name'] = mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8", "ISO-8859-1");
 
             // Add player
             $players[] = $player;

--- a/src/GameQ/Protocols/Cs2d.php
+++ b/src/GameQ/Protocols/Cs2d.php
@@ -200,8 +200,8 @@ class Cs2d extends Protocol
         $result->add('lua_scripts', (int)$this->readFlag($serverFlags, 6));
 
         // Read the rest of the buffer data
-        $result->add('servername', mb_convert_encoding($buffer->readPascalString(0), "UTF-8"));
-        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(0), "UTF-8"));
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(0), "UTF-8", "ISO-8859-1"));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(0), "UTF-8", "ISO-8859-1"));
         $result->add('num_players', $buffer->readInt8());
         $result->add('max_players', $buffer->readInt8());
         $result->add('game_mode', $buffer->readInt8());
@@ -236,7 +236,7 @@ class Cs2d extends Protocol
             if (($id = $buffer->readInt8()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(0), "UTF-8"));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(0), "UTF-8", "ISO-8859-1"));
                 $result->addPlayer('team', $buffer->readInt8());
                 $result->addPlayer('score', $buffer->readInt32());
                 $result->addPlayer('deaths', $buffer->readInt32());

--- a/src/GameQ/Protocols/Cs2d.php
+++ b/src/GameQ/Protocols/Cs2d.php
@@ -200,8 +200,8 @@ class Cs2d extends Protocol
         $result->add('lua_scripts', (int)$this->readFlag($serverFlags, 6));
 
         // Read the rest of the buffer data
-        $result->add('servername', utf8_encode($buffer->readPascalString(0)));
-        $result->add('mapname', utf8_encode($buffer->readPascalString(0)));
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(0), "UTF-8"));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(0), "UTF-8"));
         $result->add('num_players', $buffer->readInt8());
         $result->add('max_players', $buffer->readInt8());
         $result->add('game_mode', $buffer->readInt8());
@@ -236,7 +236,7 @@ class Cs2d extends Protocol
             if (($id = $buffer->readInt8()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', utf8_encode($buffer->readPascalString(0)));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(0), "UTF-8"));
                 $result->addPlayer('team', $buffer->readInt8());
                 $result->addPlayer('score', $buffer->readInt32());
                 $result->addPlayer('deaths', $buffer->readInt32());

--- a/src/GameQ/Protocols/Doom3.php
+++ b/src/GameQ/Protocols/Doom3.php
@@ -166,7 +166,7 @@ class Doom3 extends Protocol
         // Key / value pairs, delimited by an empty pair
         while ($buffer->getLength()) {
             $key = trim($buffer->readString());
-            $val = utf8_encode(trim($buffer->readString()));
+            $val = mb_convert_encoding(trim($buffer->readString()), "UTF-8");
 
             // Something is empty so we are done
             if (empty($key) && empty($val)) {
@@ -204,7 +204,7 @@ class Doom3 extends Protocol
             $result->addPlayer('ping', $buffer->readInt16());
             $result->addPlayer('rate', $buffer->readInt32());
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim($buffer->readString())));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString()), "UTF-8"));
 
             // Increment
             $playerCount++;

--- a/src/GameQ/Protocols/Doom3.php
+++ b/src/GameQ/Protocols/Doom3.php
@@ -166,7 +166,7 @@ class Doom3 extends Protocol
         // Key / value pairs, delimited by an empty pair
         while ($buffer->getLength()) {
             $key = trim($buffer->readString());
-            $val = mb_convert_encoding(trim($buffer->readString()), "UTF-8");
+            $val = mb_convert_encoding(trim($buffer->readString()), "UTF-8", "ISO-8859-1");
 
             // Something is empty so we are done
             if (empty($key) && empty($val)) {
@@ -204,7 +204,7 @@ class Doom3 extends Protocol
             $result->addPlayer('ping', $buffer->readInt16());
             $result->addPlayer('rate', $buffer->readInt32());
             // Add player name, encoded
-            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString()), "UTF-8"));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString()), "UTF-8", "ISO-8859-1"));
 
             // Increment
             $playerCount++;

--- a/src/GameQ/Protocols/Gamespy.php
+++ b/src/GameQ/Protocols/Gamespy.php
@@ -159,7 +159,7 @@ class Gamespy extends Protocol
                         if (substr($key, 0, $suffix) == 'playername') {
                             $numPlayers++;
                         }
-                        $result->addPlayer(substr($key, 0, $suffix), utf8_encode($val));
+                        $result->addPlayer(substr($key, 0, $suffix), mb_convert_encoding($val, "UTF-8"));
                     }
                 } else {
                     // Regular variable so just add the value.

--- a/src/GameQ/Protocols/Gamespy.php
+++ b/src/GameQ/Protocols/Gamespy.php
@@ -159,7 +159,7 @@ class Gamespy extends Protocol
                         if (substr($key, 0, $suffix) == 'playername') {
                             $numPlayers++;
                         }
-                        $result->addPlayer(substr($key, 0, $suffix), mb_convert_encoding($val, "UTF-8"));
+                        $result->addPlayer(substr($key, 0, $suffix), mb_convert_encoding($val, "UTF-8", "ISO-8859-1"));
                     }
                 } else {
                     // Regular variable so just add the value.

--- a/src/GameQ/Protocols/Gamespy2.php
+++ b/src/GameQ/Protocols/Gamespy2.php
@@ -182,7 +182,7 @@ class Gamespy2 extends Protocol
             if (strlen($key) == 0) {
                 break;
             }
-            $result->add($key, mb_convert_encoding($buffer->readString(), "UTF-8"));
+            $result->add($key, mb_convert_encoding($buffer->readString(), "UTF-8", "ISO-8859-1"));
         }
 
         unset($buffer);
@@ -256,7 +256,7 @@ class Gamespy2 extends Protocol
         // Get the values
         while ($buffer->getLength() > 4) {
             foreach ($varNames as $varName) {
-                $result->addSub($dataType, mb_convert_encoding($varName, "UTF-8"), mb_convert_encoding($buffer->readString(), "UTF-8"));
+                $result->addSub($dataType, mb_convert_encoding($varName, "UTF-8", "ISO-8859-1"), mb_convert_encoding($buffer->readString(), "UTF-8", "ISO-8859-1"));
             }
             if ($buffer->lookAhead() === "\x00") {
                 $buffer->skip();

--- a/src/GameQ/Protocols/Gamespy2.php
+++ b/src/GameQ/Protocols/Gamespy2.php
@@ -256,9 +256,11 @@ class Gamespy2 extends Protocol
         // Get the values
         while ($buffer->getLength() > 4) {
             foreach ($varNames as $varName) {
-                $result->addSub($dataType,
-                mb_convert_encoding($varName, "UTF-8", "ISO-8859-1"),
-                mb_convert_encoding($buffer->readString(), "UTF-8", "ISO-8859-1"));
+                $result->addSub(
+                    $dataType,
+                    mb_convert_encoding($varName, "UTF-8", "ISO-8859-1"),
+                    mb_convert_encoding($buffer->readString(), "UTF-8", "ISO-8859-1")
+                );
             }
             if ($buffer->lookAhead() === "\x00") {
                 $buffer->skip();

--- a/src/GameQ/Protocols/Gamespy2.php
+++ b/src/GameQ/Protocols/Gamespy2.php
@@ -256,7 +256,9 @@ class Gamespy2 extends Protocol
         // Get the values
         while ($buffer->getLength() > 4) {
             foreach ($varNames as $varName) {
-                $result->addSub($dataType, mb_convert_encoding($varName, "UTF-8", "ISO-8859-1"), mb_convert_encoding($buffer->readString(), "UTF-8", "ISO-8859-1"));
+                $result->addSub($dataType,
+                mb_convert_encoding($varName, "UTF-8", "ISO-8859-1"),
+                mb_convert_encoding($buffer->readString(), "UTF-8", "ISO-8859-1"));
             }
             if ($buffer->lookAhead() === "\x00") {
                 $buffer->skip();

--- a/src/GameQ/Protocols/Gamespy2.php
+++ b/src/GameQ/Protocols/Gamespy2.php
@@ -27,8 +27,8 @@ use GameQ\Result;
  * GameSpy2 Protocol class
  *
  * Given the ability for non utf-8 characters to be used as hostnames, player names, etc... this
- * version returns all strings utf-8 encoded (utf8_encode).  To access the proper version of a
- * string response you must use utf8_decode() on the specific response.
+ * version returns all strings utf-8 encoded using mb_convert_encoding(). To access the proper version of a
+ * string response you must use mb_convert_encoding() to decode the specific response.
  *
  * @author Austin Bischoff <austin@codebeard.com>
  */
@@ -182,7 +182,7 @@ class Gamespy2 extends Protocol
             if (strlen($key) == 0) {
                 break;
             }
-            $result->add($key, utf8_encode($buffer->readString()));
+            $result->add($key, mb_convert_encoding($buffer->readString(), "UTF-8"));
         }
 
         unset($buffer);
@@ -256,7 +256,7 @@ class Gamespy2 extends Protocol
         // Get the values
         while ($buffer->getLength() > 4) {
             foreach ($varNames as $varName) {
-                $result->addSub($dataType, utf8_encode($varName), utf8_encode($buffer->readString()));
+                $result->addSub($dataType, mb_convert_encoding($varName, "UTF-8"), mb_convert_encoding($buffer->readString(), "UTF-8"));
             }
             if ($buffer->lookAhead() === "\x00") {
                 $buffer->skip();

--- a/src/GameQ/Protocols/Gamespy3.php
+++ b/src/GameQ/Protocols/Gamespy3.php
@@ -252,7 +252,7 @@ class Gamespy3 extends Protocol
             if (strlen($key) == 0) {
                 break;
             }
-            $result->add($key, mb_convert_encoding($buffer->readString(), "UTF-8"));
+            $result->add($key, mb_convert_encoding($buffer->readString(), "UTF-8", "ISO-8859-1"));
         }
     }
 
@@ -328,7 +328,7 @@ class Gamespy3 extends Protocol
                         break;
                     }
                     // Add the value to the proper item in the correct group
-                    $result->addSub($item_group, $item_type, mb_convert_encoding(trim($val), "UTF-8"));
+                    $result->addSub($item_group, $item_type, mb_convert_encoding(trim($val), "UTF-8", "ISO-8859-1"));
                 }
                 // Unset our buffer
                 unset($buf_temp);

--- a/src/GameQ/Protocols/Gamespy3.php
+++ b/src/GameQ/Protocols/Gamespy3.php
@@ -26,8 +26,8 @@ use GameQ\Result;
  * GameSpy3 Protocol class
  *
  * Given the ability for non utf-8 characters to be used as hostnames, player names, etc... this
- * version returns all strings utf-8 encoded (utf8_encode).  To access the proper version of a
- * string response you must use utf8_decode() on the specific response.
+ * version returns all strings utf-8 encoded using mb_convert_encoding(). To access the proper version of a
+ * string response you must use mb_convert_encoding() to decode the specific response.
  *
  * @author Austin Bischoff <austin@codebeard.com>
  */
@@ -252,7 +252,7 @@ class Gamespy3 extends Protocol
             if (strlen($key) == 0) {
                 break;
             }
-            $result->add($key, utf8_encode($buffer->readString()));
+            $result->add($key, mb_convert_encoding($buffer->readString(), "UTF-8"));
         }
     }
 
@@ -328,7 +328,7 @@ class Gamespy3 extends Protocol
                         break;
                     }
                     // Add the value to the proper item in the correct group
-                    $result->addSub($item_group, $item_type, utf8_encode(trim($val)));
+                    $result->addSub($item_group, $item_type, mb_convert_encoding(trim($val), "UTF-8"));
                 }
                 // Unset our buffer
                 unset($buf_temp);

--- a/src/GameQ/Protocols/Killingfloor.php
+++ b/src/GameQ/Protocols/Killingfloor.php
@@ -80,10 +80,10 @@ class Killingfloor extends Unreal2
         $buffer->skip(1);
 
         // Read as a regular string since the length is incorrect (what we skipped earlier)
-        $result->add('servername', utf8_encode($buffer->readString()));
+        $result->add('servername', mb_convert_encoding($buffer->readString(), "UTF-8"));
 
         // The rest is read as normal
-        $result->add('mapname', utf8_encode($buffer->readPascalString(1)));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
         $result->add('gametype', $buffer->readPascalString(1));
         $result->add('numplayers', $buffer->readInt32());
         $result->add('maxplayers', $buffer->readInt32());

--- a/src/GameQ/Protocols/Killingfloor.php
+++ b/src/GameQ/Protocols/Killingfloor.php
@@ -80,10 +80,10 @@ class Killingfloor extends Unreal2
         $buffer->skip(1);
 
         // Read as a regular string since the length is incorrect (what we skipped earlier)
-        $result->add('servername', mb_convert_encoding($buffer->readString(), "UTF-8"));
+        $result->add('servername', mb_convert_encoding($buffer->readString(), "UTF-8", "ISO-8859-1"));
 
         // The rest is read as normal
-        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(1), "UTF-8", "ISO-8859-1"));
         $result->add('gametype', $buffer->readPascalString(1));
         $result->add('numplayers', $buffer->readInt32());
         $result->add('maxplayers', $buffer->readInt32());

--- a/src/GameQ/Protocols/Lhmp.php
+++ b/src/GameQ/Protocols/Lhmp.php
@@ -171,10 +171,10 @@ class Lhmp extends Protocol
         $result->add('password', $buffer->readString());
         $result->add('numplayers', $buffer->readInt16());
         $result->add('maxplayers', $buffer->readInt16());
-        $result->add('servername', utf8_encode($buffer->readPascalString()));
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
         $result->add('gamemode', $buffer->readPascalString());
-        $result->add('website', utf8_encode($buffer->readPascalString()));
-        $result->add('mapname', utf8_encode($buffer->readPascalString()));
+        $result->add('website', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
 
         unset($buffer);
 
@@ -203,7 +203,7 @@ class Lhmp extends Protocol
             if (($id = $buffer->readInt16()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', utf8_encode($buffer->readPascalString()));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
             }
         }
 

--- a/src/GameQ/Protocols/Lhmp.php
+++ b/src/GameQ/Protocols/Lhmp.php
@@ -171,10 +171,10 @@ class Lhmp extends Protocol
         $result->add('password', $buffer->readString());
         $result->add('numplayers', $buffer->readInt16());
         $result->add('maxplayers', $buffer->readInt16());
-        $result->add('servername', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(), "UTF-8", "ISO-8859-1"));
         $result->add('gamemode', $buffer->readPascalString());
-        $result->add('website', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
-        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
+        $result->add('website', mb_convert_encoding($buffer->readPascalString(), "UTF-8", "ISO-8859-1"));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(), "UTF-8", "ISO-8859-1"));
 
         unset($buffer);
 
@@ -203,7 +203,7 @@ class Lhmp extends Protocol
             if (($id = $buffer->readInt16()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(), "UTF-8", "ISO-8859-1"));
             }
         }
 

--- a/src/GameQ/Protocols/M2mp.php
+++ b/src/GameQ/Protocols/M2mp.php
@@ -208,7 +208,7 @@ class M2mp extends Protocol
 
             // Only player name information is available
             // Add player name, encoded
-            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readPascalString(1, true)), "UTF-8"));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readPascalString(1, true)), "UTF-8", "ISO-8859-1"));
         }
 
         // Clear

--- a/src/GameQ/Protocols/M2mp.php
+++ b/src/GameQ/Protocols/M2mp.php
@@ -208,7 +208,7 @@ class M2mp extends Protocol
 
             // Only player name information is available
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim($buffer->readPascalString(1, true))));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readPascalString(1, true)), "UTF-8"));
         }
 
         // Clear

--- a/src/GameQ/Protocols/Quake2.php
+++ b/src/GameQ/Protocols/Quake2.php
@@ -154,7 +154,7 @@ class Quake2 extends Protocol
             // Add result
             $result->add(
                 trim($buffer->readString('\\')),
-                utf8_encode(trim($buffer->readStringMulti(['\\', "\x0a"])))
+                mb_convert_encoding(trim($buffer->readStringMulti(['\\', "\x0a"])), "UTF-8")
             );
         }
 
@@ -194,7 +194,7 @@ class Quake2 extends Protocol
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim(($playerInfo->readString('"')))));
+            $result->addPlayer('name', mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8"));
 
             // Skip first "
             $playerInfo->skip(2);

--- a/src/GameQ/Protocols/Quake2.php
+++ b/src/GameQ/Protocols/Quake2.php
@@ -154,7 +154,7 @@ class Quake2 extends Protocol
             // Add result
             $result->add(
                 trim($buffer->readString('\\')),
-                mb_convert_encoding(trim($buffer->readStringMulti(['\\', "\x0a"])), "UTF-8")
+                mb_convert_encoding(trim($buffer->readStringMulti(['\\', "\x0a"])), "UTF-8", "ISO-8859-1")
             );
         }
 
@@ -194,7 +194,7 @@ class Quake2 extends Protocol
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $result->addPlayer('name', mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8"));
+            $result->addPlayer('name', mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8", "ISO-8859-1"));
 
             // Skip first "
             $playerInfo->skip(2);

--- a/src/GameQ/Protocols/Quake3.php
+++ b/src/GameQ/Protocols/Quake3.php
@@ -147,7 +147,7 @@ class Quake3 extends Protocol
             // Add result
             $result->add(
                 trim($buffer->readString('\\')),
-                utf8_encode(trim($buffer->readStringMulti(['\\', "\x0a"])))
+                mb_convert_encoding(trim($buffer->readStringMulti(['\\', "\x0a"])), "UTF-8")
             );
         }
 
@@ -195,7 +195,7 @@ class Quake3 extends Protocol
             }
 
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim($buffer->readString('"'))));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString('"')), "UTF-8"));
 
             // Burn ending delimiter
             $buffer->read();

--- a/src/GameQ/Protocols/Quake3.php
+++ b/src/GameQ/Protocols/Quake3.php
@@ -147,7 +147,7 @@ class Quake3 extends Protocol
             // Add result
             $result->add(
                 trim($buffer->readString('\\')),
-                mb_convert_encoding(trim($buffer->readStringMulti(['\\', "\x0a"])), "UTF-8")
+                mb_convert_encoding(trim($buffer->readStringMulti(['\\', "\x0a"])), "UTF-8", "ISO-8859-1")
             );
         }
 
@@ -195,7 +195,7 @@ class Quake3 extends Protocol
             }
 
             // Add player name, encoded
-            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString('"')), "UTF-8"));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString('"')), "UTF-8", "ISO-8859-1"));
 
             // Burn ending delimiter
             $buffer->read();

--- a/src/GameQ/Protocols/Quake4.php
+++ b/src/GameQ/Protocols/Quake4.php
@@ -67,7 +67,7 @@ class Quake4 extends Doom3
             $result->addPlayer('ping', $buffer->readInt16());
             $result->addPlayer('rate', $buffer->readInt32());
             // Add player name, encoded
-            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString()), "UTF-8"));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString()), "UTF-8", "ISO-8859-1"));
             $result->addPlayer('clantag', $buffer->readString());
             // Increment
             $playerCount++;

--- a/src/GameQ/Protocols/Quake4.php
+++ b/src/GameQ/Protocols/Quake4.php
@@ -67,7 +67,7 @@ class Quake4 extends Doom3
             $result->addPlayer('ping', $buffer->readInt16());
             $result->addPlayer('rate', $buffer->readInt32());
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim($buffer->readString())));
+            $result->addPlayer('name', mb_convert_encoding(trim($buffer->readString()), "UTF-8"));
             $result->addPlayer('clantag', $buffer->readString());
             // Increment
             $playerCount++;

--- a/src/GameQ/Protocols/Samp.php
+++ b/src/GameQ/Protocols/Samp.php
@@ -213,7 +213,7 @@ class Samp extends Protocol
         $result->add('max_players', $buffer->readInt16());
 
         // These are read differently for these last 3
-        $result->add('servername', utf8_encode($buffer->read($buffer->readInt32())));
+        $result->add('servername', mb_convert_encoding($buffer->read($buffer->readInt32()), "UTF-8"));
         $result->add('gametype', $buffer->read($buffer->readInt32()));
         $result->add('language', $buffer->read($buffer->readInt32()));
 
@@ -241,7 +241,7 @@ class Samp extends Protocol
         // Run until we run out of buffer
         while ($buffer->getLength()) {
             $result->addPlayer('id', $buffer->readInt8());
-            $result->addPlayer('name', utf8_encode($buffer->readPascalString()));
+            $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
             $result->addPlayer('score', $buffer->readInt32());
             $result->addPlayer('ping', $buffer->readInt32());
         }

--- a/src/GameQ/Protocols/Samp.php
+++ b/src/GameQ/Protocols/Samp.php
@@ -213,7 +213,7 @@ class Samp extends Protocol
         $result->add('max_players', $buffer->readInt16());
 
         // These are read differently for these last 3
-        $result->add('servername', mb_convert_encoding($buffer->read($buffer->readInt32()), "UTF-8"));
+        $result->add('servername', mb_convert_encoding($buffer->read($buffer->readInt32()), "UTF-8", "ISO-8859-1"));
         $result->add('gametype', $buffer->read($buffer->readInt32()));
         $result->add('language', $buffer->read($buffer->readInt32()));
 
@@ -241,7 +241,7 @@ class Samp extends Protocol
         // Run until we run out of buffer
         while ($buffer->getLength()) {
             $result->addPlayer('id', $buffer->readInt8());
-            $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(), "UTF-8"));
+            $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(), "UTF-8", "ISO-8859-1"));
             $result->addPlayer('score', $buffer->readInt32());
             $result->addPlayer('ping', $buffer->readInt32());
         }

--- a/src/GameQ/Protocols/Teamspeak2.php
+++ b/src/GameQ/Protocols/Teamspeak2.php
@@ -218,7 +218,7 @@ class Teamspeak2 extends Protocol
             list($key, $value) = explode('=', $row, 2);
 
             // Add this to the result
-            $result->add($key, mb_convert_encoding($value, "UTF-8"));
+            $result->add($key, mb_convert_encoding($value, "UTF-8", "ISO-8859-1"));
         }
 
         unset($data, $buffer, $row, $key, $value);
@@ -249,7 +249,7 @@ class Teamspeak2 extends Protocol
 
             foreach ($data as $key => $value) {
                 // Now add the data to the result
-                $result->addTeam($key, mb_convert_encoding($value, "UTF-8"));
+                $result->addTeam($key, mb_convert_encoding($value, "UTF-8", "ISO-8859-1"));
             }
         }
 
@@ -281,7 +281,7 @@ class Teamspeak2 extends Protocol
 
             foreach ($data as $key => $value) {
                 // Now add the data to the result
-                $result->addPlayer($key, mb_convert_encoding($value, "UTF-8"));
+                $result->addPlayer($key, mb_convert_encoding($value, "UTF-8", "ISO-8859-1"));
             }
         }
 

--- a/src/GameQ/Protocols/Teamspeak2.php
+++ b/src/GameQ/Protocols/Teamspeak2.php
@@ -218,7 +218,7 @@ class Teamspeak2 extends Protocol
             list($key, $value) = explode('=', $row, 2);
 
             // Add this to the result
-            $result->add($key, utf8_encode($value));
+            $result->add($key, mb_convert_encoding($value, "UTF-8"));
         }
 
         unset($data, $buffer, $row, $key, $value);
@@ -249,7 +249,7 @@ class Teamspeak2 extends Protocol
 
             foreach ($data as $key => $value) {
                 // Now add the data to the result
-                $result->addTeam($key, utf8_encode($value));
+                $result->addTeam($key, mb_convert_encoding($value, "UTF-8"));
             }
         }
 
@@ -281,7 +281,7 @@ class Teamspeak2 extends Protocol
 
             foreach ($data as $key => $value) {
                 // Now add the data to the result
-                $result->addPlayer($key, utf8_encode($value));
+                $result->addPlayer($key, mb_convert_encoding($value, "UTF-8"));
             }
         }
 

--- a/src/GameQ/Protocols/Teamspeak3.php
+++ b/src/GameQ/Protocols/Teamspeak3.php
@@ -239,7 +239,7 @@ class Teamspeak3 extends Protocol
                     ' ',
                 ],
                 $value
-            ), "UTF-8");
+            ), "UTF-8", "ISO-8859-1");
         }
 
         return $properties;

--- a/src/GameQ/Protocols/Teamspeak3.php
+++ b/src/GameQ/Protocols/Teamspeak3.php
@@ -231,7 +231,7 @@ class Teamspeak3 extends Protocol
             list($key, $value) = array_pad(explode('=', $item, 2), 2, '');
 
             // Convert spaces and other character changes
-            $properties[$key] = utf8_encode(str_replace(
+            $properties[$key] = mb_convert_encoding(str_replace(
                 [
                     '\\s', // Translate spaces
                 ],
@@ -239,7 +239,7 @@ class Teamspeak3 extends Protocol
                     ' ',
                 ],
                 $value
-            ));
+            ), "UTF-8");
         }
 
         return $properties;

--- a/src/GameQ/Protocols/Unreal2.php
+++ b/src/GameQ/Protocols/Unreal2.php
@@ -167,8 +167,8 @@ class Unreal2 extends Protocol
         $result->add('serverip', $buffer->readPascalString(1)); // empty
         $result->add('gameport', $buffer->readInt32());
         $result->add('queryport', $buffer->readInt32()); // 0
-        $result->add('servername', mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
-        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(1), "UTF-8", "ISO-8859-1"));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(1), "UTF-8", "ISO-8859-1"));
         $result->add('gametype', $buffer->readPascalString(1));
         $result->add('numplayers', $buffer->readInt32());
         $result->add('maxplayers', $buffer->readInt32());
@@ -198,7 +198,7 @@ class Unreal2 extends Protocol
             if (($id = $buffer->readInt32()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(1), "UTF-8", "ISO-8859-1"));
                 $result->addPlayer('ping', $buffer->readInt32());
                 $result->addPlayer('score', $buffer->readInt32());
 
@@ -236,7 +236,7 @@ class Unreal2 extends Protocol
                 $key .= ++$inc;
             }
 
-            $result->add(strtolower($key), mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
+            $result->add(strtolower($key), mb_convert_encoding($buffer->readPascalString(1), "UTF-8", "ISO-8859-1"));
         }
 
         unset($buffer);

--- a/src/GameQ/Protocols/Unreal2.php
+++ b/src/GameQ/Protocols/Unreal2.php
@@ -167,8 +167,8 @@ class Unreal2 extends Protocol
         $result->add('serverip', $buffer->readPascalString(1)); // empty
         $result->add('gameport', $buffer->readInt32());
         $result->add('queryport', $buffer->readInt32()); // 0
-        $result->add('servername', utf8_encode($buffer->readPascalString(1)));
-        $result->add('mapname', utf8_encode($buffer->readPascalString(1)));
+        $result->add('servername', mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
+        $result->add('mapname', mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
         $result->add('gametype', $buffer->readPascalString(1));
         $result->add('numplayers', $buffer->readInt32());
         $result->add('maxplayers', $buffer->readInt32());
@@ -198,7 +198,7 @@ class Unreal2 extends Protocol
             if (($id = $buffer->readInt32()) !== 0) {
                 // Add the results
                 $result->addPlayer('id', $id);
-                $result->addPlayer('name', utf8_encode($buffer->readPascalString(1)));
+                $result->addPlayer('name', mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
                 $result->addPlayer('ping', $buffer->readInt32());
                 $result->addPlayer('score', $buffer->readInt32());
 
@@ -236,7 +236,7 @@ class Unreal2 extends Protocol
                 $key .= ++$inc;
             }
 
-            $result->add(strtolower($key), utf8_encode($buffer->readPascalString(1)));
+            $result->add(strtolower($key), mb_convert_encoding($buffer->readPascalString(1), "UTF-8"));
         }
 
         unset($buffer);

--- a/src/GameQ/Protocols/Ventrilo.php
+++ b/src/GameQ/Protocols/Ventrilo.php
@@ -723,7 +723,7 @@ class Ventrilo extends Protocol
 
                     // By default we just add they key as an item
                     default:
-                        $result->add($key, utf8_encode($value));
+                        $result->add($key, mb_convert_encoding($value, "UTF-8"));
                         break;
                 }
             }
@@ -849,7 +849,7 @@ class Ventrilo extends Protocol
             // Split the key=value pair
             list($key, $value) = explode("=", $item, 2);
 
-            $result->addTeam(strtolower($key), utf8_encode($value));
+            $result->addTeam(strtolower($key), mb_convert_encoding($value, "UTF-8"));
         }
     }
 
@@ -871,7 +871,7 @@ class Ventrilo extends Protocol
             // Split the key=value pair
             list($key, $value) = explode("=", $item, 2);
 
-            $result->addPlayer(strtolower($key), utf8_encode($value));
+            $result->addPlayer(strtolower($key), mb_convert_encoding($value, "UTF-8"));
         }
     }
 }

--- a/src/GameQ/Protocols/Ventrilo.php
+++ b/src/GameQ/Protocols/Ventrilo.php
@@ -723,7 +723,7 @@ class Ventrilo extends Protocol
 
                     // By default we just add they key as an item
                     default:
-                        $result->add($key, mb_convert_encoding($value, "UTF-8"));
+                        $result->add($key, mb_convert_encoding($value, "UTF-8", "ISO-8859-1"));
                         break;
                 }
             }
@@ -849,7 +849,7 @@ class Ventrilo extends Protocol
             // Split the key=value pair
             list($key, $value) = explode("=", $item, 2);
 
-            $result->addTeam(strtolower($key), mb_convert_encoding($value, "UTF-8"));
+            $result->addTeam(strtolower($key), mb_convert_encoding($value, "UTF-8", "ISO-8859-1"));
         }
     }
 
@@ -871,7 +871,7 @@ class Ventrilo extends Protocol
             // Split the key=value pair
             list($key, $value) = explode("=", $item, 2);
 
-            $result->addPlayer(strtolower($key), mb_convert_encoding($value, "UTF-8"));
+            $result->addPlayer(strtolower($key), mb_convert_encoding($value, "UTF-8", "ISO-8859-1"));
         }
     }
 }

--- a/src/GameQ/Protocols/Warsow.php
+++ b/src/GameQ/Protocols/Warsow.php
@@ -76,7 +76,7 @@ class Warsow extends Quake3
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $result->addPlayer('name', utf8_encode(trim(($playerInfo->readString('"')))));
+            $result->addPlayer('name', mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8"));
 
             // Skip space
             $playerInfo->skip(1);

--- a/src/GameQ/Protocols/Warsow.php
+++ b/src/GameQ/Protocols/Warsow.php
@@ -76,7 +76,7 @@ class Warsow extends Quake3
             $playerInfo->skip(1);
 
             // Add player name, encoded
-            $result->addPlayer('name', mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8"));
+            $result->addPlayer('name', mb_convert_encoding(trim(($playerInfo->readString('"'))), "UTF-8", "ISO-8859-1"));
 
             // Skip space
             $playerInfo->skip(1);


### PR DESCRIPTION
…ed by mb_convert_encoding()

The utf8_encode() function is deprecated in php 8 and has been replaced by mb_convert_encoding()